### PR TITLE
Restore Tailwind utility generation and fix global styles so site styling loads

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,10 +1,8 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import "tailwindcss";
 
 @layer base {
   html {
-    @apply bg-background-primary;
+    background-color: #0a0a0a;
     scroll-behavior: smooth;
     scroll-padding-top: 8rem;
     font-size: 15px;
@@ -12,9 +10,8 @@
   }
 
   body {
-    /* Set a green background for testing */
-    background-color: green;
-    @apply text-content-primary;
+    background-color: #0a0a0a;
+    color: #ffffff;
     line-height: 1.6;
     cursor: url('/images/dot_cursor.png') 8 8, auto;
     overflow-x: hidden;
@@ -24,7 +21,13 @@
 
   h2::after {
     content: '';
-    @apply absolute bottom-0 left-0 h-[3px] w-[60px] rounded-full bg-accent;
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    height: 3px;
+    width: 60px;
+    border-radius: 9999px;
+    background-color: #00b4d8;
   }
 
   header::before,
@@ -50,12 +53,12 @@
     height: 10px;
   }
   ::-webkit-scrollbar-track {
-    @apply bg-background-tertiary rounded-sm;
+    background-color: #1a1a1a;
+    border-radius: 4px;
   }
   ::-webkit-scrollbar-thumb {
-    @apply rounded-sm;
+    border-radius: 4px;
     background: #444;
-    /* Replaced theme() function with the actual hex code to resolve build error */
     border: 2px solid #1a1a1a;
     transition: background 300ms;
   }
@@ -63,17 +66,14 @@
     background: #555;
   }
   ::-webkit-scrollbar-thumb:active {
-    @apply bg-accent;
+    background-color: #00b4d8;
   }
   ::-webkit-scrollbar-corner {
-    @apply bg-background-tertiary;
+    background-color: #1a1a1a;
   }
 
   * {
     scrollbar-width: thin;
-    /* Replaced theme() function with the actual hex code to resolve build error */
     scrollbar-color: #444 #1a1a1a;
   }
 }
-
-

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -1,87 +1,63 @@
-// tailwind.config.mjs
-import defaultTheme from 'tailwindcss/defaultTheme';
+import defaultTheme from 'tailwindcss/defaultTheme'
 
 /** @type {import('tailwindcss').Config} */
 export default {
-  content: [
-    './src/**/*.{js,ts,jsx,tsx}',
-  ],
-  // In Tailwind CSS v4, customizations go directly into the `theme` object,
-  // not under `theme.extend`.
+  content: ['./src/**/*.{js,ts,jsx,tsx}'],
   theme: {
-    // === Colors ===
-    colors: {
-      background: {
-        primary: '#0a0a0a',
-        secondary: '#151515',
-        tertiary: '#1a1a1a',
-        nav: 'rgba(10, 10, 10, 0.95)',
+    extend: {
+      colors: {
+        bg: {
+          primary: '#0a0a0a',
+          secondary: '#151515',
+          tertiary: '#1a1a1a',
+          nav: 'rgba(10, 10, 10, 0.95)',
+        },
+        text: {
+          primary: '#ffffff',
+          secondary: '#e0e0e0',
+        },
+        background: {
+          primary: '#0a0a0a',
+          secondary: '#151515',
+          tertiary: '#1a1a1a',
+          nav: 'rgba(10, 10, 10, 0.95)',
+        },
+        content: {
+          primary: '#ffffff',
+          secondary: '#e0e0e0',
+        },
+        accent: {
+          DEFAULT: '#00b4d8',
+          hover: '#00d4f8',
+        },
+        border: '#2a2a2a',
+        error: '#ff4444',
+        success: '#00c853',
+        warning: '#ffd600',
       },
-      content: {
-        primary: '#ffffff',
-        secondary: '#e0e0e0',
+      fontFamily: {
+        sans: ['var(--font-inter)', ...defaultTheme.fontFamily.sans],
+        mono: ['var(--font-jetbrains-mono)', ...defaultTheme.fontFamily.mono],
       },
-      accent: {
-        DEFAULT: '#00b4d8',
-        hover: '#00d4f8',
+      keyframes: {
+        'fade-in': {
+          from: { opacity: '0' },
+          to: { opacity: '1' },
+        },
+        'slide-up': {
+          from: { opacity: '0', transform: 'translateY(30px)' },
+          to: { opacity: '1', transform: 'translateY(0)' },
+        },
+        spinner: {
+          to: { transform: 'rotate(360deg)' },
+        },
       },
-      border: '#2a2a2a',
-      error: '#ff4444',
-      success: '#00c853',
-      warning: '#ffd600',
-    },
-    // === Fonts ===
-    fontFamily: {
-      sans: ['var(--font-inter)', ...defaultTheme.fontFamily.sans],
-      mono: ['var(--font-jetbrains-mono)', ...defaultTheme.fontFamily.mono],
-    },
-    // === Spacing ===
-    spacing: {
-      'xs': '0.5rem',
-      'sm': '1rem',
-      'md': '1.5rem',
-      'lg': '2.5rem',
-      'xl': '4rem',
-    },
-    // === Border Radius ===
-    borderRadius: {
-      'sm': '4px',
-      'md': '8px',
-      'lg': '12px',
-      'full': '9999px',
-    },
-    // === Box Shadow ===
-    boxShadow: {
-      'sm': '0 2px 4px rgba(0, 0, 0, 0.2)',
-      'md': '0 4px 12px rgba(0, 0, 0, 0.3)',
-      'lg': '0 8px 24px rgba(0, 0, 0, 0.4)',
-    },
-    // === Transitions ===
-    transitionDuration: {
-      DEFAULT: '300ms',
-      fast: '200ms',
-      normal: '300ms',
-      slow: '500ms',
-    },
-    // === Keyframes & Animations ===
-    keyframes: {
-      'fade-in': {
-        'from': { opacity: '0' },
-        'to': { opacity: '1' },
+      animation: {
+        'fade-in': 'fade-in 0.5s ease forwards',
+        'slide-up': 'slide-up 0.6s ease forwards',
+        spinner: 'spinner 1s linear infinite',
       },
-      'slide-up': {
-        'from': { opacity: '0', transform: 'translateY(30px)' },
-        'to': { opacity: '1', transform: 'translateY(0)' },
-      },
-      spinner: {
-        'to': { transform: 'rotate(360deg)' },
-      },
-    },
-    animation: {
-      'fade-in': 'fade-in 0.5s ease forwards',
-      'slide-up': 'slide-up 0.6s ease forwards',
-      spinner: 'spinner 1s linear infinite',
     },
   },
   plugins: [],
-};
+}


### PR DESCRIPTION
### Motivation
- The site lost Tailwind-generated utilities because the global stylesheet used legacy directives and `@apply` rules referencing custom utilities that weren't being generated, causing layout to fall back to unstyled defaults.
- The Tailwind config replaced core theme values rather than extending them, which prevented default utilities (spacing, radii, etc.) from being available and caused class name mismatches.

### Description
- Replaced legacy Tailwind entrypoint with `@import "tailwindcss";` in `src/app/globals.css` to ensure Tailwind v4 generates utility classes again.
- Removed problematic `@apply` usages in `src/app/globals.css` and converted those rules to plain CSS (base page colors, pseudo-element sizing, and scrollbar styles) to avoid unknown-utility compile errors.
- Updated `tailwind.config.mjs` to use `theme.extend` and added matching color namespaces (`bg`, `text`, `background`, `content`) plus font/animation tokens so existing class names used throughout the codebase resolve correctly.
- Adjusted a few explicit CSS properties (e.g., `h2::after`, scrollbar rules) to concrete values so styles apply even when Tailwind utilities were not available during build/dev in this environment.

### Testing
- Ran `npm run lint` which completed successfully with no ESLint warnings or errors.
- Attempted `npm run build` which failed due to inability to fetch Google Fonts from `fonts.googleapis.com` in this environment and not because of Tailwind/CSS errors.
- Verified styles in an automated browser check using Playwright which confirmed the `body` background is `rgb(10, 10, 10)` and the `h1` gradient utilities are applied, and captured a screenshot artifact of the restored homepage.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8da7277dc83329c990ee798aff68a)