### PR TITLE
Fix robots metadata route for static export builds

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,5 +1,7 @@
 import type { MetadataRoute } from 'next'
 
+export const dynamic = 'force-static'
+
 export default function robots(): MetadataRoute.Robots {
   return {
     rules: {


### PR DESCRIPTION
### Motivation
- Ensure the `/robots.txt` metadata route is compatible with Next.js `output: 'export'` static HTML export mode by forcing the route to be static.

### Description
- Add `export const dynamic = 'force-static'` to `src/app/robots.ts` so the robots metadata route is treated as a static route during export.

### Testing
- Ran `npm run build`; the previous `/robots.txt` static-export error is resolved but the build fails later due to network failures fetching Google Fonts (`Inter` and `JetBrains Mono`) from `fonts.googleapis.com`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3e698c6248332ae8b9bd4788796a2)