### PR TITLE
Improve homepage messaging, add audience-split paths and contact intake; update roadmap

### DIFF
--- a/docs/portfolio-improvements-roadmap.md
+++ b/docs/portfolio-improvements-roadmap.md
@@ -4,6 +4,51 @@ This document is a prioritized, idea-rich backlog for leveling up your portfolio
 
 ---
 
+## Progress Snapshot (Updated: 2026-04-06)
+
+### Completed in this pass
+- [x] **1.1 Clear one-line value proposition (hero)** — Updated home hero copy to focus on outcomes and changed CTA to include **Book a Call**.
+- [x] **1.2 Audience split CTA** — Added "I’m hiring" and "I need a developer" path cards on the homepage.
+- [x] **3.2 Publish a now/upcoming panel** — Added a compact "Currently building / Exploring / Available for" panel.
+- [x] **4.2 Better contact conversion** — Contact form now includes project type, budget range, timeline, and goals; direct email fallback is now visible.
+
+### Already completed before this pass
+- [x] **2.3 Introduce project taxonomy filters** — Projects page already has interactive category filters.
+- [x] **7.3 Resume integration** — Site already includes embedded resume preview + downloadable PDF.
+- [x] **6.2 Rich metadata and social cards (partial)** — Structured data and metadata are already present in layout.
+
+### Not completed yet
+- [ ] **1.3 Personal brand consistency**
+- [ ] **2.1 Structured case-study format**
+- [ ] **2.2 Measurable impact snippets**
+- [ ] **2.4 Deep dive pages**
+- [ ] **3.1 Social proof modules**
+- [ ] **3.3 Featured in / Open Source section**
+- [ ] **3.4 Timeline highlights**
+- [ ] **4.1 Sticky action bar**
+- [ ] **4.3 Purposeful microinteractions**
+- [ ] **4.4 Improve scanability**
+- [ ] **5.1 Performance budget + monitoring**
+- [ ] **5.2 Accessibility hardening pass**
+- [ ] **5.3 Quality signals**
+- [ ] **5.4 Enhanced error and empty states**
+- [ ] **6.1 Search-intent pages**
+- [ ] **6.2 Rich metadata and social cards (remaining items)**
+- [ ] **6.3 Blog/notes section**
+- [ ] **6.4 Internal linking strategy**
+- [ ] **7.1 About page rewrite for outcomes**
+- [ ] **7.2 Skills section: evidence-based**
+- [ ] **7.4 Working With Me section**
+- [ ] **8.1 Funnel analytics**
+- [ ] **8.2 CTA event tracking**
+- [ ] **8.3 A/B experiments**
+- [ ] **8.4 Monthly review ritual**
+- [ ] **9.1 Interactive project demos**
+- [ ] **9.2 Recruiter mode**
+- [ ] **9.3 AI-assisted site search**
+
+---
+
 ## 1) Positioning & Messaging Upgrades
 
 ### 1.1 Clear one-line value proposition (hero)

--- a/src/components/pages/ContactPageClient.tsx
+++ b/src/components/pages/ContactPageClient.tsx
@@ -9,15 +9,19 @@ import { FaGithub, FaLinkedin, FaTwitter, FaYoutube } from 'react-icons/fa'
 interface FormData {
   name: string
   email: string
-  subject: string
-  message: string
+  projectType: string
+  budgetRange: string
+  timeline: string
+  goals: string
 }
 
 interface FormErrors {
   name: string
   email: string
-  subject: string
-  message: string
+  projectType: string
+  budgetRange: string
+  timeline: string
+  goals: string
 }
 
 interface SocialLink {
@@ -86,15 +90,19 @@ const ContactPage: React.FC = () => {
   const [formData, setFormData] = useState<FormData>({
     name: '',
     email: '',
-    subject: '',
-    message: '',
+    projectType: '',
+    budgetRange: '',
+    timeline: '',
+    goals: '',
   })
 
   const [errors, setErrors] = useState<FormErrors>({
     name: '',
     email: '',
-    subject: '',
-    message: '',
+    projectType: '',
+    budgetRange: '',
+    timeline: '',
+    goals: '',
   })
 
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -130,8 +138,10 @@ const ContactPage: React.FC = () => {
     const nextErrors: FormErrors = {
       name: '',
       email: '',
-      subject: '',
-      message: '',
+      projectType: '',
+      budgetRange: '',
+      timeline: '',
+      goals: '',
     }
 
     let valid = true
@@ -149,13 +159,23 @@ const ContactPage: React.FC = () => {
       valid = false
     }
 
-    if (!formData.subject.trim()) {
-      nextErrors.subject = 'Subject is required.'
+    if (!formData.projectType.trim()) {
+      nextErrors.projectType = 'Project type is required.'
       valid = false
     }
 
-    if (!formData.message.trim()) {
-      nextErrors.message = 'Message is required.'
+    if (!formData.budgetRange.trim()) {
+      nextErrors.budgetRange = 'Budget range is required.'
+      valid = false
+    }
+
+    if (!formData.timeline.trim()) {
+      nextErrors.timeline = 'Timeline is required.'
+      valid = false
+    }
+
+    if (!formData.goals.trim()) {
+      nextErrors.goals = 'Goals are required.'
       valid = false
     }
 
@@ -203,8 +223,15 @@ const ContactPage: React.FC = () => {
           body: JSON.stringify({
             name: formData.name.trim(),
             email: formData.email.trim(),
-            subject: formData.subject.trim(),
-            message: formData.message.trim(),
+            subject: `Portfolio inquiry: ${formData.projectType.trim()} (${formData.timeline.trim()})`,
+            message: [
+              `Project type: ${formData.projectType.trim()}`,
+              `Budget range: ${formData.budgetRange.trim()}`,
+              `Timeline: ${formData.timeline.trim()}`,
+              '',
+              'Goals:',
+              formData.goals.trim(),
+            ].join('\n'),
             turnstileToken,
           }),
         }
@@ -226,8 +253,10 @@ const ContactPage: React.FC = () => {
       setFormData({
         name: '',
         email: '',
-        subject: '',
-        message: '',
+        projectType: '',
+        budgetRange: '',
+        timeline: '',
+        goals: '',
       })
       setTurnstileToken('')
       window.turnstile?.reset()
@@ -277,7 +306,7 @@ const ContactPage: React.FC = () => {
         <div className="rounded-3xl border border-cyan-300/15 bg-cyan-500/[0.04] p-6 md:p-8">
           <h2>Send a Message</h2>
           <p className="mt-3 max-w-2xl text-white/80">
-            Fill out the form below and I’ll respond as soon as I can.
+            Share a few project details and I&apos;ll reply with a focused next step.
           </p>
 
           <form onSubmit={handleSubmit} className="mt-6 space-y-5">
@@ -318,36 +347,74 @@ const ContactPage: React.FC = () => {
             </div>
 
             <div>
-              <label htmlFor="subject" className={labelClassName}>
-                Subject
+              <label htmlFor="projectType" className={labelClassName}>
+                Project Type
               </label>
               <input
                 type="text"
-                id="subject"
-                name="subject"
-                value={formData.subject}
+                id="projectType"
+                name="projectType"
+                value={formData.projectType}
                 onChange={handleInputChange}
                 className={inputClassName}
+                placeholder="e.g., marketing site, dashboard, redesign"
               />
-              {errors.subject && (
-                <p className="mt-2 text-sm text-red-400">{errors.subject}</p>
+              {errors.projectType && (
+                <p className="mt-2 text-sm text-red-400">{errors.projectType}</p>
               )}
             </div>
 
             <div>
-              <label htmlFor="message" className={labelClassName}>
-                Message
+              <label htmlFor="budgetRange" className={labelClassName}>
+                Budget Range
+              </label>
+              <input
+                type="text"
+                id="budgetRange"
+                name="budgetRange"
+                value={formData.budgetRange}
+                onChange={handleInputChange}
+                className={inputClassName}
+                placeholder="e.g., $2k-$5k"
+              />
+              {errors.budgetRange && (
+                <p className="mt-2 text-sm text-red-400">{errors.budgetRange}</p>
+              )}
+            </div>
+
+            <div>
+              <label htmlFor="timeline" className={labelClassName}>
+                Timeline
+              </label>
+              <input
+                type="text"
+                id="timeline"
+                name="timeline"
+                value={formData.timeline}
+                onChange={handleInputChange}
+                className={inputClassName}
+                placeholder="e.g., launch in 6 weeks"
+              />
+              {errors.timeline && (
+                <p className="mt-2 text-sm text-red-400">{errors.timeline}</p>
+              )}
+            </div>
+
+            <div>
+              <label htmlFor="goals" className={labelClassName}>
+                Goals
               </label>
               <textarea
-                id="message"
-                name="message"
+                id="goals"
+                name="goals"
                 rows={7}
-                value={formData.message}
+                value={formData.goals}
                 onChange={handleInputChange}
                 className={`${inputClassName} resize-y`}
+                placeholder="What should this project achieve?"
               />
-              {errors.message && (
-                <p className="mt-2 text-sm text-red-400">{errors.message}</p>
+              {errors.goals && (
+                <p className="mt-2 text-sm text-red-400">{errors.goals}</p>
               )}
             </div>
 
@@ -393,6 +460,16 @@ const ContactPage: React.FC = () => {
             <h2>Connect With Me</h2>
             <p className="mt-3 text-white/80">
               You can also find me on these platforms.
+            </p>
+            <p className="mt-3 text-white/80">
+              Prefer email? Reach out directly at{' '}
+              <a
+                href="mailto:Jeremy@jeremymhayes.com"
+                className="font-semibold text-cyan-200 underline decoration-cyan-300/50 underline-offset-4 hover:text-cyan-100"
+              >
+                Jeremy@jeremymhayes.com
+              </a>
+              .
             </p>
           </div>
 

--- a/src/components/pages/HomePageClient.tsx
+++ b/src/components/pages/HomePageClient.tsx
@@ -67,12 +67,12 @@ const HomePage: React.FC = () => {
         </p>
 
         <h1 className="max-w-3xl text-balance text-3xl font-bold leading-tight md:text-5xl">
-          Building polished digital experiences for the web and game platforms.
+          I design and build fast, accessible web apps that turn visitors into customers.
         </h1>
 
         <p className="mt-5 max-w-2xl text-base text-white/80 md:text-lg">
-          I build modern websites, interactive systems, and game projects with a focus
-          on performance, usability, and clean execution.
+          From landing pages to production dashboards, I focus on measurable outcomes:
+          performance, conversion, and maintainable delivery.
         </p>
 
         <div className="mt-6 flex flex-wrap gap-3">
@@ -83,8 +83,46 @@ const HomePage: React.FC = () => {
 
           <Link href="/contact" className={secondaryButtonClassName}>
             <FaEnvelope aria-hidden="true" className="h-[16px] w-[16px]" />
-            <span>Contact Me</span>
+            <span>Book a Call</span>
           </Link>
+        </div>
+      </motion.section>
+
+      <motion.section className={panelClassName} {...sectionTransition(0.05)}>
+        <h2>Choose Your Path</h2>
+        <p className="mt-3 max-w-2xl text-white/80">
+          Whether you&apos;re hiring or need a developer partner, start with the path that matches your goal.
+        </p>
+
+        <div className="mt-7 grid grid-cols-1 gap-4 md:grid-cols-2">
+          <div className="rounded-2xl border border-white/10 bg-white/[0.03] p-5">
+            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-cyan-300/80">I&apos;m hiring</p>
+            <h3 className="mt-3 text-xl font-semibold text-white">See role-fit proof quickly</h3>
+            <p className="mt-3 text-white/75">
+              Review highlighted projects, relevant skills, and my current resume in one pass.
+            </p>
+            <div className="mt-5 flex flex-wrap gap-3">
+              <Link href="/projects" className={secondaryButtonClassName}>
+                View Selected Work
+              </Link>
+              <a href="/JeremyHayesResume.pdf" className={secondaryButtonClassName}>
+                Open Resume
+              </a>
+            </div>
+          </div>
+
+          <div className="rounded-2xl border border-cyan-300/20 bg-cyan-500/[0.08] p-5">
+            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-cyan-300/90">I need a developer</p>
+            <h3 className="mt-3 text-xl font-semibold text-white">Plan and ship with confidence</h3>
+            <p className="mt-3 text-white/75">
+              Share scope, timeline, and goals to get a structured response and next steps.
+            </p>
+            <div className="mt-5">
+              <Link href="/contact" className={primaryButtonClassName}>
+                Start a Project Conversation
+              </Link>
+            </div>
+          </div>
         </div>
       </motion.section>
 
@@ -164,6 +202,21 @@ const HomePage: React.FC = () => {
         className="rounded-3xl border border-cyan-300/15 bg-gradient-to-r from-cyan-500/10 via-sky-500/5 to-transparent p-8 md:p-12"
         {...sectionTransition(0.2)}
       >
+        <div className="mb-10 grid gap-4 md:grid-cols-3">
+          <div className="rounded-2xl border border-white/10 bg-black/20 p-5">
+            <h3 className="text-lg font-semibold text-white">Currently building</h3>
+            <p className="mt-2 text-white/75">Faster case-study pages with clearer impact snapshots.</p>
+          </div>
+          <div className="rounded-2xl border border-white/10 bg-black/20 p-5">
+            <h3 className="text-lg font-semibold text-white">Exploring</h3>
+            <p className="mt-2 text-white/75">Performance tooling and reusable UI patterns for content-heavy pages.</p>
+          </div>
+          <div className="rounded-2xl border border-white/10 bg-black/20 p-5">
+            <h3 className="text-lg font-semibold text-white">Available for</h3>
+            <p className="mt-2 text-white/75">Frontend, full-stack web projects, and targeted performance improvements.</p>
+          </div>
+        </div>
+
         <h2 className="mb-4 text-center after:left-1/2 after:-translate-x-1/2">
           Stay Updated
         </h2>


### PR DESCRIPTION
### Motivation
- Improve clarity and conversion by moving the hero to an outcome-first value proposition and surfacing clear CTAs for different visitor intents. 
- Capture higher-quality inbound leads by turning the contact page into a short intake form that collects project context instead of a generic message. 
- Record progress against the roadmap so ongoing work is visible and tracked in the docs.

### Description
- Updated `src/components/pages/HomePageClient.tsx` to use an outcome-first hero, change the secondary CTA to `Book a Call`, and add an audience split panel ("I’m hiring" / "I need a developer") and a compact "Currently building / Exploring / Available for" panel. 
- Reworked `src/components/pages/ContactPageClient.tsx` to replace free-form `subject`/`message` with structured intake fields: `projectType`, `budgetRange`, `timeline`, and `goals`, and composed these into the existing API payload so backend compatibility is preserved. 
- Added a direct email fallback link to the contact area (`mailto:Jeremy@jeremymhayes.com`) for visitors who prefer email. 
- Updated `docs/portfolio-improvements-roadmap.md` with a dated `Progress Snapshot` listing completed items from this pass and remaining checklist items.

### Testing
- Ran linting with `npm run lint` and confirmed there were no ESLint warnings or errors (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3f0633ec883329ebac4f0b4e77fb1)