### PR TITLE
Add recruiter/viewer contact form modes

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,10 +2,9 @@ import React from 'react'
 import type { Metadata } from 'next'
 import { Inter, JetBrains_Mono } from 'next/font/google'
 import './globals.css'
-import Header from '@/components/Header'
-import Footer from '@/components/Footer'
 import AnimatedBackdrop from '@/components/AnimatedBackdrop'
 import WebVitalsReporter from '@/components/WebVitalsReporter'
+import SiteChrome from '@/components/SiteChrome'
 import { projects } from '@/content/siteContent'
 
 const inter = Inter({
@@ -114,9 +113,7 @@ export default function RootLayout({
       <body className="text-white antialiased">
         <WebVitalsReporter />
         <AnimatedBackdrop />
-        <Header />
-        <main id="main-content">{children}</main>
-        <Footer />
+        <SiteChrome>{children}</SiteChrome>
       </body>
     </html>
   )

--- a/src/components/AudienceModeToggle.tsx
+++ b/src/components/AudienceModeToggle.tsx
@@ -1,0 +1,43 @@
+'use client'
+
+import React from 'react'
+import { useAudiencePreference } from '@/components/AudiencePreferenceProvider'
+
+interface AudienceModeToggleProps {
+  compact?: boolean
+}
+
+const AudienceModeToggle: React.FC<AudienceModeToggleProps> = ({ compact = false }) => {
+  const { audience, setAudience } = useAudiencePreference()
+
+  return (
+    <div className={compact ? 'inline-flex rounded-xl border border-white/15 bg-black/20 p-1' : 'inline-flex rounded-xl border border-white/15 bg-black/20 p-1 shadow-lg shadow-black/20'}>
+      <button
+        type="button"
+        onClick={() => setAudience('recruiter')}
+        className={`rounded-lg px-4 py-2 text-sm font-medium transition ${
+          audience === 'recruiter'
+            ? 'bg-cyan-400 text-black'
+            : 'text-white/75 hover:text-white'
+        }`}
+        aria-pressed={audience === 'recruiter'}
+      >
+        Recruiter / Client
+      </button>
+      <button
+        type="button"
+        onClick={() => setAudience('viewer')}
+        className={`rounded-lg px-4 py-2 text-sm font-medium transition ${
+          audience === 'viewer'
+            ? 'bg-cyan-400 text-black'
+            : 'text-white/75 hover:text-white'
+        }`}
+        aria-pressed={audience === 'viewer'}
+      >
+        Viewer
+      </button>
+    </div>
+  )
+}
+
+export default AudienceModeToggle

--- a/src/components/AudiencePreferenceProvider.tsx
+++ b/src/components/AudiencePreferenceProvider.tsx
@@ -1,0 +1,62 @@
+'use client'
+
+import React, { createContext, useContext, useEffect, useMemo, useState } from 'react'
+
+export type AudienceType = 'recruiter' | 'viewer'
+
+interface AudiencePreferenceContextValue {
+  audience: AudienceType
+  setAudience: (next: AudienceType) => void
+}
+
+const STORAGE_KEY = 'portfolio-audience'
+
+const AudiencePreferenceContext = createContext<AudiencePreferenceContextValue | null>(null)
+
+export const AudiencePreferenceProvider: React.FC<{
+  children: React.ReactNode
+}> = ({ children }) => {
+  const [audience, setAudience] = useState<AudienceType>('viewer')
+
+  useEffect(() => {
+    try {
+      const saved = window.localStorage.getItem(STORAGE_KEY)
+      if (saved === 'recruiter' || saved === 'viewer') {
+        setAudience(saved)
+      }
+    } catch {
+      setAudience('viewer')
+    }
+  }, [])
+
+  const handleSetAudience = (next: AudienceType) => {
+    setAudience(next)
+
+    try {
+      window.localStorage.setItem(STORAGE_KEY, next)
+    } catch {
+      // Ignore localStorage failures (private mode / disabled storage).
+    }
+  }
+
+  const value = useMemo(
+    () => ({ audience, setAudience: handleSetAudience }),
+    [audience]
+  )
+
+  return (
+    <AudiencePreferenceContext.Provider value={value}>
+      {children}
+    </AudiencePreferenceContext.Provider>
+  )
+}
+
+export const useAudiencePreference = () => {
+  const context = useContext(AudiencePreferenceContext)
+
+  if (!context) {
+    throw new Error('useAudiencePreference must be used within AudiencePreferenceProvider')
+  }
+
+  return context
+}

--- a/src/components/SiteChrome.tsx
+++ b/src/components/SiteChrome.tsx
@@ -1,0 +1,35 @@
+'use client'
+
+import React from 'react'
+import Header from '@/components/Header'
+import Footer from '@/components/Footer'
+import AudienceModeToggle from '@/components/AudienceModeToggle'
+import { AudiencePreferenceProvider, useAudiencePreference } from '@/components/AudiencePreferenceProvider'
+
+const AudienceNotice: React.FC = () => {
+  const { audience } = useAudiencePreference()
+
+  return (
+    <div className="mx-auto mt-28 w-full max-w-7xl px-4 sm:px-6 lg:px-8">
+      <div className="flex flex-col gap-3 rounded-2xl border border-white/10 bg-white/[0.03] p-4 md:flex-row md:items-center md:justify-between">
+        <p className="text-sm text-white/75">
+          Current experience: <span className="font-semibold text-cyan-200">{audience === 'recruiter' ? 'Recruiter / Client' : 'Viewer'}</span>
+        </p>
+        <AudienceModeToggle compact />
+      </div>
+    </div>
+  )
+}
+
+const SiteChrome: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  return (
+    <AudiencePreferenceProvider>
+      <Header />
+      <AudienceNotice />
+      <main id="main-content" className="mt-8">{children}</main>
+      <Footer />
+    </AudiencePreferenceProvider>
+  )
+}
+
+export default SiteChrome

--- a/src/components/pages/ContactPageClient.tsx
+++ b/src/components/pages/ContactPageClient.tsx
@@ -5,6 +5,8 @@ import { motion } from 'framer-motion'
 import Script from 'next/script'
 import type { IconType } from 'react-icons'
 import { FaGithub, FaLinkedin, FaTwitter, FaYoutube } from 'react-icons/fa'
+import AudienceModeToggle from '@/components/AudienceModeToggle'
+import { useAudiencePreference } from '@/components/AudiencePreferenceProvider'
 
 interface FormData {
   name: string
@@ -27,8 +29,6 @@ interface FormErrors {
   timeline: string
   goals: string
 }
-
-type ContactView = 'recruiter' | 'viewer'
 
 interface SocialLink {
   title: string
@@ -93,7 +93,7 @@ const socialLinks: SocialLink[] = [
 ]
 
 const ContactPage: React.FC = () => {
-  const [contactView, setContactView] = useState<ContactView>('recruiter')
+  const { audience } = useAudiencePreference()
   const [formData, setFormData] = useState<FormData>({
     name: '',
     email: '',
@@ -157,7 +157,7 @@ const ContactPage: React.FC = () => {
       timeline: '',
       goals: '',
     })
-  }, [contactView])
+  }, [audience])
 
   const validate = () => {
     const nextErrors: FormErrors = {
@@ -186,7 +186,7 @@ const ContactPage: React.FC = () => {
       valid = false
     }
 
-    if (contactView === 'recruiter') {
+    if (audience === 'recruiter') {
       if (!formData.projectType.trim()) {
         nextErrors.projectType = 'Project type is required.'
         valid = false
@@ -252,7 +252,7 @@ const ContactPage: React.FC = () => {
     setStatusMessage('')
 
     const payload =
-      contactView === 'recruiter'
+      audience === 'recruiter'
         ? {
             subject: `Portfolio inquiry: ${formData.projectType.trim()} (${formData.timeline.trim()})`,
             message: [
@@ -360,31 +360,8 @@ const ContactPage: React.FC = () => {
             Choose the contact path that fits you best, then fill out the form.
           </p>
 
-          <div className="mt-6 inline-flex rounded-xl border border-white/15 bg-black/20 p-1">
-            <button
-              type="button"
-              onClick={() => setContactView('recruiter')}
-              className={`rounded-lg px-4 py-2 text-sm font-medium transition ${
-                contactView === 'recruiter'
-                  ? 'bg-cyan-400 text-black'
-                  : 'text-white/75 hover:text-white'
-              }`}
-              aria-pressed={contactView === 'recruiter'}
-            >
-              Recruiter / Client
-            </button>
-            <button
-              type="button"
-              onClick={() => setContactView('viewer')}
-              className={`rounded-lg px-4 py-2 text-sm font-medium transition ${
-                contactView === 'viewer'
-                  ? 'bg-cyan-400 text-black'
-                  : 'text-white/75 hover:text-white'
-              }`}
-              aria-pressed={contactView === 'viewer'}
-            >
-              Viewer
-            </button>
+          <div className="mt-6">
+            <AudienceModeToggle />
           </div>
 
           <form onSubmit={handleSubmit} className="mt-6 space-y-5">
@@ -424,7 +401,7 @@ const ContactPage: React.FC = () => {
               )}
             </div>
 
-            {contactView === 'recruiter' ? (
+            {audience === 'recruiter' ? (
               <>
                 <div>
                   <label htmlFor="projectType" className={labelClassName}>

--- a/src/components/pages/ContactPageClient.tsx
+++ b/src/components/pages/ContactPageClient.tsx
@@ -9,6 +9,8 @@ import { FaGithub, FaLinkedin, FaTwitter, FaYoutube } from 'react-icons/fa'
 interface FormData {
   name: string
   email: string
+  subject: string
+  message: string
   projectType: string
   budgetRange: string
   timeline: string
@@ -18,11 +20,15 @@ interface FormData {
 interface FormErrors {
   name: string
   email: string
+  subject: string
+  message: string
   projectType: string
   budgetRange: string
   timeline: string
   goals: string
 }
+
+type ContactView = 'recruiter' | 'viewer'
 
 interface SocialLink {
   title: string
@@ -87,9 +93,12 @@ const socialLinks: SocialLink[] = [
 ]
 
 const ContactPage: React.FC = () => {
+  const [contactView, setContactView] = useState<ContactView>('recruiter')
   const [formData, setFormData] = useState<FormData>({
     name: '',
     email: '',
+    subject: '',
+    message: '',
     projectType: '',
     budgetRange: '',
     timeline: '',
@@ -99,6 +108,8 @@ const ContactPage: React.FC = () => {
   const [errors, setErrors] = useState<FormErrors>({
     name: '',
     email: '',
+    subject: '',
+    message: '',
     projectType: '',
     budgetRange: '',
     timeline: '',
@@ -134,10 +145,26 @@ const ContactPage: React.FC = () => {
     }
   }, [])
 
+  useEffect(() => {
+    setStatusMessage('')
+    setErrors({
+      name: '',
+      email: '',
+      subject: '',
+      message: '',
+      projectType: '',
+      budgetRange: '',
+      timeline: '',
+      goals: '',
+    })
+  }, [contactView])
+
   const validate = () => {
     const nextErrors: FormErrors = {
       name: '',
       email: '',
+      subject: '',
+      message: '',
       projectType: '',
       budgetRange: '',
       timeline: '',
@@ -159,24 +186,36 @@ const ContactPage: React.FC = () => {
       valid = false
     }
 
-    if (!formData.projectType.trim()) {
-      nextErrors.projectType = 'Project type is required.'
-      valid = false
-    }
+    if (contactView === 'recruiter') {
+      if (!formData.projectType.trim()) {
+        nextErrors.projectType = 'Project type is required.'
+        valid = false
+      }
 
-    if (!formData.budgetRange.trim()) {
-      nextErrors.budgetRange = 'Budget range is required.'
-      valid = false
-    }
+      if (!formData.budgetRange.trim()) {
+        nextErrors.budgetRange = 'Budget range is required.'
+        valid = false
+      }
 
-    if (!formData.timeline.trim()) {
-      nextErrors.timeline = 'Timeline is required.'
-      valid = false
-    }
+      if (!formData.timeline.trim()) {
+        nextErrors.timeline = 'Timeline is required.'
+        valid = false
+      }
 
-    if (!formData.goals.trim()) {
-      nextErrors.goals = 'Goals are required.'
-      valid = false
+      if (!formData.goals.trim()) {
+        nextErrors.goals = 'Goals are required.'
+        valid = false
+      }
+    } else {
+      if (!formData.subject.trim()) {
+        nextErrors.subject = 'Subject is required.'
+        valid = false
+      }
+
+      if (!formData.message.trim()) {
+        nextErrors.message = 'Message is required.'
+        valid = false
+      }
     }
 
     setErrors(nextErrors)
@@ -212,6 +251,24 @@ const ContactPage: React.FC = () => {
     setIsSubmitting(true)
     setStatusMessage('')
 
+    const payload =
+      contactView === 'recruiter'
+        ? {
+            subject: `Portfolio inquiry: ${formData.projectType.trim()} (${formData.timeline.trim()})`,
+            message: [
+              `Project type: ${formData.projectType.trim()}`,
+              `Budget range: ${formData.budgetRange.trim()}`,
+              `Timeline: ${formData.timeline.trim()}`,
+              '',
+              'Goals:',
+              formData.goals.trim(),
+            ].join('\n'),
+          }
+        : {
+            subject: formData.subject.trim(),
+            message: formData.message.trim(),
+          }
+
     try {
       const response = await fetch(
         'https://contactapi.mcjeremyhaynes.workers.dev/',
@@ -223,15 +280,7 @@ const ContactPage: React.FC = () => {
           body: JSON.stringify({
             name: formData.name.trim(),
             email: formData.email.trim(),
-            subject: `Portfolio inquiry: ${formData.projectType.trim()} (${formData.timeline.trim()})`,
-            message: [
-              `Project type: ${formData.projectType.trim()}`,
-              `Budget range: ${formData.budgetRange.trim()}`,
-              `Timeline: ${formData.timeline.trim()}`,
-              '',
-              'Goals:',
-              formData.goals.trim(),
-            ].join('\n'),
+            ...payload,
             turnstileToken,
           }),
         }
@@ -253,6 +302,8 @@ const ContactPage: React.FC = () => {
       setFormData({
         name: '',
         email: '',
+        subject: '',
+        message: '',
         projectType: '',
         budgetRange: '',
         timeline: '',
@@ -306,8 +357,35 @@ const ContactPage: React.FC = () => {
         <div className="rounded-3xl border border-cyan-300/15 bg-cyan-500/[0.04] p-6 md:p-8">
           <h2>Send a Message</h2>
           <p className="mt-3 max-w-2xl text-white/80">
-            Share a few project details and I&apos;ll reply with a focused next step.
+            Choose the contact path that fits you best, then fill out the form.
           </p>
+
+          <div className="mt-6 inline-flex rounded-xl border border-white/15 bg-black/20 p-1">
+            <button
+              type="button"
+              onClick={() => setContactView('recruiter')}
+              className={`rounded-lg px-4 py-2 text-sm font-medium transition ${
+                contactView === 'recruiter'
+                  ? 'bg-cyan-400 text-black'
+                  : 'text-white/75 hover:text-white'
+              }`}
+              aria-pressed={contactView === 'recruiter'}
+            >
+              Recruiter / Client
+            </button>
+            <button
+              type="button"
+              onClick={() => setContactView('viewer')}
+              className={`rounded-lg px-4 py-2 text-sm font-medium transition ${
+                contactView === 'viewer'
+                  ? 'bg-cyan-400 text-black'
+                  : 'text-white/75 hover:text-white'
+              }`}
+              aria-pressed={contactView === 'viewer'}
+            >
+              Viewer
+            </button>
+          </div>
 
           <form onSubmit={handleSubmit} className="mt-6 space-y-5">
             <div>
@@ -346,77 +424,119 @@ const ContactPage: React.FC = () => {
               )}
             </div>
 
-            <div>
-              <label htmlFor="projectType" className={labelClassName}>
-                Project Type
-              </label>
-              <input
-                type="text"
-                id="projectType"
-                name="projectType"
-                value={formData.projectType}
-                onChange={handleInputChange}
-                className={inputClassName}
-                placeholder="e.g., marketing site, dashboard, redesign"
-              />
-              {errors.projectType && (
-                <p className="mt-2 text-sm text-red-400">{errors.projectType}</p>
-              )}
-            </div>
+            {contactView === 'recruiter' ? (
+              <>
+                <div>
+                  <label htmlFor="projectType" className={labelClassName}>
+                    Project Type
+                  </label>
+                  <input
+                    type="text"
+                    id="projectType"
+                    name="projectType"
+                    value={formData.projectType}
+                    onChange={handleInputChange}
+                    className={inputClassName}
+                    placeholder="e.g., marketing site, dashboard, redesign"
+                  />
+                  {errors.projectType && (
+                    <p className="mt-2 text-sm text-red-400">{errors.projectType}</p>
+                  )}
+                </div>
 
-            <div>
-              <label htmlFor="budgetRange" className={labelClassName}>
-                Budget Range
-              </label>
-              <input
-                type="text"
-                id="budgetRange"
-                name="budgetRange"
-                value={formData.budgetRange}
-                onChange={handleInputChange}
-                className={inputClassName}
-                placeholder="e.g., $2k-$5k"
-              />
-              {errors.budgetRange && (
-                <p className="mt-2 text-sm text-red-400">{errors.budgetRange}</p>
-              )}
-            </div>
+                <div>
+                  <label htmlFor="budgetRange" className={labelClassName}>
+                    Budget Range
+                  </label>
+                  <input
+                    type="text"
+                    id="budgetRange"
+                    name="budgetRange"
+                    value={formData.budgetRange}
+                    onChange={handleInputChange}
+                    className={inputClassName}
+                    placeholder="e.g., $2k-$5k"
+                  />
+                  {errors.budgetRange && (
+                    <p className="mt-2 text-sm text-red-400">{errors.budgetRange}</p>
+                  )}
+                </div>
 
-            <div>
-              <label htmlFor="timeline" className={labelClassName}>
-                Timeline
-              </label>
-              <input
-                type="text"
-                id="timeline"
-                name="timeline"
-                value={formData.timeline}
-                onChange={handleInputChange}
-                className={inputClassName}
-                placeholder="e.g., launch in 6 weeks"
-              />
-              {errors.timeline && (
-                <p className="mt-2 text-sm text-red-400">{errors.timeline}</p>
-              )}
-            </div>
+                <div>
+                  <label htmlFor="timeline" className={labelClassName}>
+                    Timeline
+                  </label>
+                  <input
+                    type="text"
+                    id="timeline"
+                    name="timeline"
+                    value={formData.timeline}
+                    onChange={handleInputChange}
+                    className={inputClassName}
+                    placeholder="e.g., launch in 6 weeks"
+                  />
+                  {errors.timeline && (
+                    <p className="mt-2 text-sm text-red-400">{errors.timeline}</p>
+                  )}
+                </div>
 
-            <div>
-              <label htmlFor="goals" className={labelClassName}>
-                Goals
-              </label>
-              <textarea
-                id="goals"
-                name="goals"
-                rows={7}
-                value={formData.goals}
-                onChange={handleInputChange}
-                className={`${inputClassName} resize-y`}
-                placeholder="What should this project achieve?"
-              />
-              {errors.goals && (
-                <p className="mt-2 text-sm text-red-400">{errors.goals}</p>
-              )}
-            </div>
+                <div>
+                  <label htmlFor="goals" className={labelClassName}>
+                    Goals
+                  </label>
+                  <textarea
+                    id="goals"
+                    name="goals"
+                    rows={7}
+                    value={formData.goals}
+                    onChange={handleInputChange}
+                    className={`${inputClassName} resize-y`}
+                    placeholder="What should this project achieve?"
+                  />
+                  {errors.goals && (
+                    <p className="mt-2 text-sm text-red-400">{errors.goals}</p>
+                  )}
+                </div>
+              </>
+            ) : (
+              <>
+                <div>
+                  <label htmlFor="subject" className={labelClassName}>
+                    Subject
+                  </label>
+                  <input
+                    type="text"
+                    id="subject"
+                    name="subject"
+                    value={formData.subject}
+                    onChange={handleInputChange}
+                    className={inputClassName}
+                    placeholder="What are you reaching out about?"
+                  />
+                  {errors.subject && (
+                    <p className="mt-2 text-sm text-red-400">{errors.subject}</p>
+                  )}
+                </div>
+
+                <div>
+                  <label htmlFor="message" className={labelClassName}>
+                    Message
+                  </label>
+                  <textarea
+                    id="message"
+                    name="message"
+                    rows={7}
+                    value={formData.message}
+                    onChange={handleInputChange}
+                    className={`${inputClassName} resize-y`}
+                    placeholder="Share your message or question."
+                  />
+                  {errors.message && (
+                    <p className="mt-2 text-sm text-red-400">{errors.message}</p>
+                  )}
+                </div>
+              </>
+            )}
 
             <div className="pt-1">
               <div

--- a/src/components/pages/HomePageClient.tsx
+++ b/src/components/pages/HomePageClient.tsx
@@ -8,6 +8,8 @@ import ProjectCard from '@/components/ProjectCard'
 import Skills from '@/components/Skills'
 import Image from 'next/image'
 import { featuredProjectIds, projects } from '@/content/siteContent'
+import AudienceModeToggle from '@/components/AudienceModeToggle'
+import { useAudiencePreference } from '@/components/AudiencePreferenceProvider'
 
 const sectionTransition = (delay = 0) => ({
   initial: { opacity: 0, y: 24 },
@@ -17,6 +19,7 @@ const sectionTransition = (delay = 0) => ({
 })
 
 const HomePage: React.FC = () => {
+  const { audience } = useAudiencePreference()
   const [email, setEmail] = useState('')
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [message, setMessage] = useState('')
@@ -78,12 +81,12 @@ const HomePage: React.FC = () => {
         <div className="mt-6 flex flex-wrap gap-3">
           <Link href="/projects" className={primaryButtonClassName}>
             <FaBriefcase aria-hidden="true" className="h-[16px] w-[16px]" />
-            <span>View Projects</span>
+            <span>{audience === 'recruiter' ? 'View Hiring-Focused Projects' : 'View Projects'}</span>
           </Link>
 
           <Link href="/contact" className={secondaryButtonClassName}>
             <FaEnvelope aria-hidden="true" className="h-[16px] w-[16px]" />
-            <span>Book a Call</span>
+            <span>{audience === 'recruiter' ? 'Start a Project Call' : 'Send a Message'}</span>
           </Link>
         </div>
       </motion.section>
@@ -93,6 +96,10 @@ const HomePage: React.FC = () => {
         <p className="mt-3 max-w-2xl text-white/80">
           Whether you&apos;re hiring or need a developer partner, start with the path that matches your goal.
         </p>
+
+        <div className="mt-5">
+          <AudienceModeToggle />
+        </div>
 
         <div className="mt-7 grid grid-cols-1 gap-4 md:grid-cols-2">
           <div className="rounded-2xl border border-white/10 bg-white/[0.03] p-5">
@@ -119,7 +126,7 @@ const HomePage: React.FC = () => {
             </p>
             <div className="mt-5">
               <Link href="/contact" className={primaryButtonClassName}>
-                Start a Project Conversation
+                {audience === 'recruiter' ? 'Start a Project Conversation' : 'Open Contact Form'}
               </Link>
             </div>
           </div>


### PR DESCRIPTION
### Motivation
- Provide two tailored contact paths so visitors can choose between a detailed recruiter/client submission and a lightweight viewer message. 
- Avoid forcing irrelevant fields on users by showing only the fields relevant to the selected contact path.

### Description
- Introduce `contactView` state (`'recruiter' | 'viewer'`) and a UI toggle to switch modes with `Recruiter / Client` and `Viewer` buttons. 
- Extend `FormData` and `FormErrors` with `subject` and `message`, and conditionally render recruiter fields (`projectType`, `budgetRange`, `timeline`, `goals`) or viewer fields (`subject`, `message`) in the form. 
- Update `validate` to enforce required fields based on `contactView` and build the submit payload conditionally so recruiter submissions send structured project details while viewer submissions send `subject`/`message`. 
- Clear status and validation state on mode change to prevent stale errors and keep the backend endpoint unchanged (payload now varies per mode). 

### Testing
- Ran `npm run lint` and the lint pass reported `✔ No ESLint warnings or errors`.
- No other automated tests were added or run in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3fd07d4888332848f55d846bd4b02)