### PR TITLE
Add persistent sticky action bar for Projects/Resume/Contact

### DIFF
--- a/docs/portfolio-improvements-roadmap.md
+++ b/docs/portfolio-improvements-roadmap.md
@@ -11,6 +11,7 @@ This document is a prioritized, idea-rich backlog for leveling up your portfolio
 - [x] **1.2 Audience split CTA** — Added "I’m hiring" and "I need a developer" path cards on the homepage.
 - [x] **3.2 Publish a now/upcoming panel** — Added a compact "Currently building / Exploring / Available for" panel.
 - [x] **4.2 Better contact conversion** — Contact form now includes project type, budget range, timeline, and goals; direct email fallback is now visible.
+- [x] **4.1 Sticky action bar** — Added a persistent bottom action bar with quick links to **Projects**, **Resume**, and **Contact**.
 
 ### Already completed before this pass
 - [x] **2.3 Introduce project taxonomy filters** — Projects page already has interactive category filters.
@@ -25,7 +26,7 @@ This document is a prioritized, idea-rich backlog for leveling up your portfolio
 - [ ] **3.1 Social proof modules**
 - [ ] **3.3 Featured in / Open Source section**
 - [ ] **3.4 Timeline highlights**
-- [ ] **4.1 Sticky action bar**
+- [x] **4.1 Sticky action bar**
 - [ ] **4.3 Purposeful microinteractions**
 - [ ] **4.4 Improve scanability**
 - [ ] **5.1 Performance budget + monitoring**

--- a/src/components/SiteChrome.tsx
+++ b/src/components/SiteChrome.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import React from 'react'
+import Link from 'next/link'
 import Header from '@/components/Header'
 import Footer from '@/components/Footer'
 import AudienceModeToggle from '@/components/AudienceModeToggle'
@@ -21,13 +22,35 @@ const AudienceNotice: React.FC = () => {
   )
 }
 
+const StickyActionBar: React.FC = () => {
+  const actionClassName =
+    'inline-flex min-h-10 items-center justify-center rounded-lg border border-white/15 bg-white/5 px-4 text-sm font-medium text-white transition-colors duration-200 hover:border-cyan-300/50 hover:bg-cyan-400/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300/80'
+
+  return (
+    <div className="fixed inset-x-0 bottom-4 z-40 px-4 sm:bottom-5">
+      <div className="mx-auto flex w-full max-w-xl items-center justify-center gap-2 rounded-2xl border border-white/15 bg-black/70 p-2 shadow-lg shadow-black/40 backdrop-blur-md">
+        <Link href="/projects" className={actionClassName}>
+          Projects
+        </Link>
+        <a href="/JeremyHayesResume.pdf" className={actionClassName}>
+          Resume
+        </a>
+        <Link href="/contact" className={actionClassName}>
+          Contact
+        </Link>
+      </div>
+    </div>
+  )
+}
+
 const SiteChrome: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   return (
     <AudiencePreferenceProvider>
       <Header />
       <AudienceNotice />
-      <main id="main-content" className="mt-8">{children}</main>
+      <main id="main-content" className="mt-8 pb-24">{children}</main>
       <Footer />
+      <StickyActionBar />
     </AudiencePreferenceProvider>
   )
 }


### PR DESCRIPTION
### Motivation
- Keep key CTAs visible across pages so visitors can quickly access Projects, Resume, or Contact without needing to scroll back to the header. 
- Prevent the fixed bar from overlapping content by reserving space at the bottom of the main content area. 
- Reflect the implemented UI improvement in the project roadmap so progress tracking stays up to date.

### Description
- Add a new `StickyActionBar` component in `src/components/SiteChrome.tsx` that renders a fixed bottom bar with quick links to `Projects`, the `Resume` PDF, and `Contact`. 
- Import `next/link` and apply accessible, reusable button class names and layout styles for the action buttons, and append the `StickyActionBar` to the site chrome. 
- Add bottom padding to the main content (`pb-24`) to avoid overlap with the fixed action bar. 
- Update `docs/portfolio-improvements-roadmap.md` to mark **4.1 Sticky action bar** as completed.

### Testing
- Ran `npm run lint` and the project reported no ESLint warnings or errors. 
- Ran `npm run typecheck` (`tsc --noEmit`) and type checking completed successfully. 
- Ran `npm test` and the test suite passed (`1` test passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d473b58b6c8332bbd06b97151e93a3)